### PR TITLE
优化网站导航与响应式体验

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: dsh 中文实战书
-site_description: dsh 中文实战书稿：从基础使用到 Harness、Cordis 与插件扩展
+site_name: DeepSeek Harness 中文实战书
+site_description: DeepSeek Harness 中文实战书稿：从基础使用到 Harness、Cordis 与插件扩展
 site_url: https://dshbook.penguin.ooo/
 repo_name: Prism-Shadow/dsh-book
 repo_url: https://github.com/Prism-Shadow/dsh-book
@@ -19,6 +19,8 @@ theme:
   language: zh
   custom_dir: site/overrides
   font: false
+  icon:
+    repo: fontawesome/brands/github
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -68,6 +70,7 @@ extra_css:
   - stylesheets/extra.css
 
 extra_javascript:
+  - javascripts/sidebar-toggle.js
   - javascripts/drawer-scroll-lock.js
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/site/javascripts/sidebar-toggle.js
+++ b/site/javascripts/sidebar-toggle.js
@@ -1,0 +1,31 @@
+(() => {
+  const storageKey = "book-sidebar-collapsed";
+  const root = document.documentElement;
+  const button = document.querySelector("[data-book-sidebar-toggle]");
+  const sidebar = document.querySelector(".md-sidebar--primary");
+
+  if (!button || !sidebar) return;
+
+  sidebar.id = "book-primary-sidebar";
+  button.setAttribute("aria-controls", sidebar.id);
+
+  const updateButton = () => {
+    const collapsed = root.classList.contains("book-sidebar-collapsed");
+    const label = collapsed ? "显示章节目录" : "隐藏章节目录";
+    button.setAttribute("aria-expanded", String(!collapsed));
+    button.setAttribute("aria-label", label);
+    button.dataset.bookTooltip = label;
+  };
+
+  button.addEventListener("click", () => {
+    const collapsed = root.classList.toggle("book-sidebar-collapsed");
+    try {
+      localStorage.setItem(storageKey, String(collapsed));
+    } catch {
+      // 浏览器禁用本地存储时，开关在当前页面中仍可正常使用。
+    }
+    updateButton();
+  });
+
+  updateButton();
+})();

--- a/site/overrides/main.html
+++ b/site/overrides/main.html
@@ -16,6 +16,13 @@
 
 {% block extrahead %}
   {{ super() }}
+  <script>
+    try {
+      if (localStorage.getItem("book-sidebar-collapsed") === "true") {
+        document.documentElement.classList.add("book-sidebar-collapsed");
+      }
+    } catch {}
+  </script>
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ book_title }}">
   <meta property="og:title" content="{{ book_title if page and page.is_homepage else (page.title if page and page.title else book_title) }}">

--- a/site/overrides/partials/header.html
+++ b/site/overrides/partials/header.html
@@ -1,0 +1,77 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <span class="md-header__button md-logo book-header-logo" data-book-tooltip="{{ config.site_name | e }}" role="img" aria-label="{{ config.site_name }}">
+      {% include "partials/logo.html" %}
+    </span>
+    <button type="button" class="md-header__button md-icon book-sidebar-toggle" data-book-tooltip="隐藏章节目录" aria-label="隐藏章节目录" aria-expanded="true" data-book-sidebar-toggle>
+      <span class="book-sidebar-toggle__icon book-sidebar-toggle__icon--collapse">
+        {% include ".icons/material/menu-open.svg" %}
+      </span>
+      <span class="book-sidebar-toggle__icon book-sidebar-toggle__icon--expand">
+        {% include ".icons/material/menu-close.svg" %}
+      </span>
+    </button>
+    <label class="md-header__button md-icon" for="__drawer" data-book-tooltip="打开章节目录" aria-label="打开章节目录">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search" data-book-tooltip="搜索" aria-label="搜索">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/site/overrides/partials/home.html
+++ b/site/overrides/partials/home.html
@@ -1,8 +1,8 @@
 <section class="home-hero" aria-labelledby="home-title">
-  <p class="home-hero__eyebrow">dsh 中文实战书</p>
+  <p class="home-hero__eyebrow">DeepSeek Harness 中文实战书</p>
   <h1 id="home-title">从零开始玩转 DeepSeek Harness</h1>
   <p class="home-hero__lead">
-    从安装和第一次任务开始，学会让 dsh 调用工具、读写文件，并把它扩展成自己的 Agent Harness。
+    从安装和第一次任务开始，带你学会让 DeepSeek Harness（简称 dsh）调用工具、读写文件，并把它扩展成自己的 Agent Harness。
   </p>
   <div class="home-hero__actions">
     <a class="md-button md-button--primary" href="{{ 'chapter1/' | url }}">从第1章开始</a>

--- a/site/overrides/partials/nav.html
+++ b/site/overrides/partials/nav.html
@@ -1,0 +1,45 @@
+{#-
+  将全书的“部分”渲染为静态分组标题，章节保持完整可见。
+-#}
+{% import "partials/nav-item.html" as item with context %}
+{% set class = "md-nav md-nav--primary" %}
+{% if "navigation.tabs" in features %}
+  {% set class = class ~ " md-nav--lifted" %}
+{% endif %}
+{% if "toc.integrate" in features %}
+  {% set class = class ~ " md-nav--integrated" %}
+{% endif %}
+<nav class="{{ class }}" aria-label="{{ lang.t('nav') }}" data-md-level="0">
+  <label class="md-nav__title" for="__drawer">
+    <span class="md-nav__button md-logo book-nav-logo" role="img" aria-label="{{ config.site_name }}">
+      {% include "partials/logo.html" %}
+    </span>
+    {{ config.site_name }}
+  </label>
+  {% if config.repo_url %}
+    <div class="md-nav__source">
+      {% include "partials/source.html" %}
+    </div>
+  {% endif %}
+  <ul class="md-nav__list" data-md-scrollfix>
+    {% for nav_item in nav.items %}
+      {% set path = "__nav_" ~ loop.index %}
+      {% if nav_item.children %}
+        {% set group_class = "md-nav__item book-nav-group" %}
+        {% if nav_item.active %}
+          {% set group_class = group_class ~ " book-nav-group--active" %}
+        {% endif %}
+        <li class="{{ group_class }}">
+          <strong class="book-nav-group__title">{{ item.render_title(nav_item) }}</strong>
+          <ul class="md-nav__list book-nav-group__list">
+            {% for child in nav_item.children %}
+              {{ item.render(child, path ~ "_" ~ loop.index, 2, nav_item) }}
+            {% endfor %}
+          </ul>
+        </li>
+      {% else %}
+        {{ item.render(nav_item, path, 1) }}
+      {% endif %}
+    {% endfor %}
+  </ul>
+</nav>

--- a/site/overrides/partials/palette.html
+++ b/site/overrides/partials/palette.html
@@ -1,0 +1,16 @@
+{#-
+  Material 主题的配色开关，改用站内悬停提示。
+-#}
+<form class="md-header__option" data-md-component="palette">
+  {% for option in config.theme.palette %}
+    {% set scheme  = option.scheme  | d("default", true) %}
+    {% set primary = option.primary | d("indigo", true) %}
+    {% set accent  = option.accent  | d("indigo", true) %}
+    <input class="md-option" data-md-color-media="{{ option.media }}" data-md-color-scheme="{{ scheme | replace(' ', '-') }}" data-md-color-primary="{{ primary | replace(' ', '-') }}" data-md-color-accent="{{ accent | replace(' ', '-') }}" {% if option.toggle %} aria-label="{{ option.toggle.name }}" {% else %} aria-hidden="true" {% endif %} type="radio" name="__palette" id="__palette_{{ loop.index0 }}">
+    {% if option.toggle %}
+      <label class="md-header__button md-icon" data-book-tooltip="{{ option.toggle.name }}" aria-label="{{ option.toggle.name }}" for="__palette_{{ loop.index % loop.length }}" hidden>
+        {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+      </label>
+    {% endif %}
+  {% endfor %}
+</form>

--- a/site/overrides/partials/source.html
+++ b/site/overrides/partials/source.html
@@ -1,0 +1,12 @@
+{#-
+  仓库入口改用站内悬停提示。
+-#}
+<a href="{{ config.repo_url }}" class="md-source" data-md-component="source" data-book-tooltip="{{ lang.t('source') }}" aria-label="{{ lang.t('source') }}">
+  <div class="md-source__icon md-icon">
+    {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
+    {% include ".icons/" ~ icon ~ ".svg" %}
+  </div>
+  <div class="md-source__repository">
+    {{ config.repo_name }}
+  </div>
+</a>

--- a/site/stylesheets/extra.css
+++ b/site/stylesheets/extra.css
@@ -287,6 +287,163 @@ input {
   display: none;
 }
 
+.book-header-logo,
+.book-nav-logo {
+  cursor: default;
+}
+
+/* 顶栏按钮使用即时可见的站内提示，不依赖浏览器延迟显示 title。 */
+.md-header [data-book-tooltip] {
+  position: relative;
+}
+
+.md-header [data-book-tooltip]::after {
+  background: var(--md-default-fg-color);
+  border-radius: 0.12rem;
+  box-shadow: var(--md-shadow-z1);
+  color: var(--md-default-bg-color);
+  content: attr(data-book-tooltip);
+  font-size: 0.64rem;
+  font-weight: 400;
+  left: 50%;
+  line-height: 1.2;
+  opacity: 0;
+  padding: 0.35rem 0.45rem;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  transform: translateX(-50%);
+  transition: opacity 120ms ease;
+  visibility: hidden;
+  white-space: nowrap;
+  z-index: 5;
+}
+
+.md-header [data-book-tooltip]:hover::after,
+.md-header [data-book-tooltip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+.md-header .book-header-logo::after {
+  left: 0;
+  transform: none;
+}
+
+.md-header label[for="__drawer"]::after {
+  left: 0;
+  transform: none;
+}
+
+.md-header__source .md-source::after {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+
+.md-header__inner .book-sidebar-toggle {
+  display: none;
+}
+
+.book-sidebar-toggle__icon {
+  display: block;
+  height: 1.2rem;
+  width: 1.2rem;
+}
+
+.book-sidebar-toggle__icon > svg {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.book-sidebar-toggle__icon--expand,
+html.book-sidebar-collapsed .book-sidebar-toggle__icon--collapse {
+  display: none;
+}
+
+html.book-sidebar-collapsed .book-sidebar-toggle__icon--expand {
+  display: block;
+}
+
+/* “部分”只作为目录分隔标题，所有章节始终显示。 */
+.book-nav-group {
+  margin: 6px 0;
+}
+
+.book-nav-group__title {
+  color: var(--md-default-fg-color);
+  display: block;
+  font-size: 15px;
+  font-weight: 800;
+  line-height: 30px;
+  margin: 0;
+  padding: 0;
+}
+
+.book-nav-group__list {
+  margin: 0;
+  padding: 0;
+}
+
+.book-nav-group__list > .md-nav__item {
+  box-sizing: border-box;
+  margin: 6px 0;
+  padding-left: 15px;
+}
+
+.book-nav-group__list > .md-nav__item > .md-nav__link {
+  font-size: 14px;
+  line-height: 30px;
+  margin: 0;
+  padding: 0;
+}
+
+/* Material 在窄屏目录中默认给每一项加边框，这里改回书籍目录的平铺样式。 */
+.md-nav--primary .book-nav-group,
+.md-nav--primary .book-nav-group__list > .md-nav__item {
+  border-top: 0;
+}
+
+/* 隐藏章节目录的滚动条外观，同时保留滚轮和触控滚动。 */
+.md-sidebar--primary .md-sidebar__scrollwrap,
+.md-sidebar--primary .md-nav--primary > .md-nav__list {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.md-sidebar--primary .md-sidebar__scrollwrap::-webkit-scrollbar,
+.md-sidebar--primary .md-nav--primary > .md-nav__list::-webkit-scrollbar {
+  height: 0;
+  width: 0;
+}
+
+@media screen and (min-width: 76.25em) {
+  .md-header__inner .book-sidebar-toggle {
+    display: block;
+  }
+
+  html.book-sidebar-collapsed .md-sidebar--primary {
+    display: none;
+  }
+
+  .md-sidebar--primary {
+    width: 15rem;
+  }
+
+  [dir="ltr"] .md-sidebar--primary .md-sidebar__inner {
+    padding-right: 0.6rem;
+  }
+
+  [dir="rtl"] .md-sidebar--primary .md-sidebar__inner {
+    padding-left: 0.6rem;
+  }
+
+  .book-nav-group__list > .md-nav__item {
+    padding-left: 3px;
+  }
+}
+
 /* 页脚保留版权与前后章导航，弱化模板署名区域的视觉重量。 */
 .md-footer-meta {
   background: var(--md-default-bg-color);
@@ -314,6 +471,29 @@ input {
 
   .md-sidebar--primary .md-nav__list {
     overscroll-behavior-y: contain;
+  }
+
+  .md-sidebar--primary .md-nav--primary > .md-nav__list {
+    overflow-x: hidden;
+  }
+
+  /* 所有章节统一预留目录图标列，避免当前章节切换时标题重新换行。 */
+  .book-nav-group__list > .md-nav__item > .md-nav__link {
+    box-sizing: border-box;
+    padding-inline-end: 28px;
+    position: relative;
+  }
+
+  .book-nav-group__list
+    > .md-nav__item
+    > label.md-nav__link--active
+    .md-nav__icon {
+    height: 20px;
+    inset-inline-end: 4px;
+    margin: 0;
+    position: absolute;
+    top: 5px;
+    width: 20px;
   }
 
   .md-overlay {


### PR DESCRIPTION
## 主要改动

- 将网站名称统一为“DeepSeek Harness 中文实战书”，并在首页说明 dsh 是其简称
- 将侧边目录改为始终展开的章节分组，调整宽度、字号、行距和响应式断点
- 增加宽屏章节目录开关，并保存用户的展开状态
- 优化顶栏图标、GitHub 入口和即时悬停说明，取消左上角书籍标识的主页链接
- 修正窄屏章内目录图标的对齐与标题换行抖动，隐藏目录滚动条但保留滚动能力

## 验证

- `python3 scripts/prepare_site.py`
- `PYTHONPATH=tmp/site-deps python3 -m mkdocs build --strict`
- `git diff --check`
- 审计 23 个生成页面的内部链接、资源、锚点和重复 ID
- 检查 15 个主要页面在 1440、1220、1219、1000 和 600px 下的布局、图片、横向溢出及控制台错误
- 验证宽屏目录开关与状态保存、中屏章内目录、窄屏抽屉及悬停提示
