### PR TITLE
build: 新增 Typst 版 PDF 构建链路

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -59,3 +59,67 @@ jobs:
         with:
           path: ~/.TinyTeX
           key: ${{ steps.cache-tex.outputs.cache-primary-key }}
+
+  typst-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils
+
+      - name: Install Typst
+        env:
+          TYPST_VERSION: v0.15.1
+        run: |
+          curl -fsSL -o typst.tar.xz \
+            "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz"
+          tar xf typst.tar.xz
+          sudo install -m 755 typst-x86_64-unknown-linux-musl/typst /usr/local/bin/typst
+          rm -rf typst.tar.xz typst-x86_64-unknown-linux-musl
+          typst --version
+
+      # inelegant-note 指定思源宋体 / 思源黑体，Ubuntu 源里只有同源的 Noto CJK，
+      # 家族名对不上，所以直接取 Adobe 发行版。模板经 cuti 伪粗体渲染中文字重，
+      # 只需要 Regular 和 Bold 两个字重，缓存约 84MB。
+      - name: Restore Source Han fonts
+        id: cache-fonts
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/fonts/source-han
+          key: source-han-sc-serif-2.003R-sans-2.005R
+
+      - name: Install Source Han fonts
+        if: steps.cache-fonts.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/share/fonts/source-han
+          install_family() {
+            curl -fsSL -o fonts.zip "$1"
+            unzip -j -o fonts.zip "OTF/SimplifiedChinese/$2-Regular.otf" \
+              "OTF/SimplifiedChinese/$2-Bold.otf" -d ~/.local/share/fonts/source-han
+            rm fonts.zip
+          }
+          install_family \
+            "https://github.com/adobe-fonts/source-han-serif/releases/download/2.003R/09_SourceHanSerifSC.zip" \
+            SourceHanSerifSC
+          install_family \
+            "https://github.com/adobe-fonts/source-han-sans/releases/download/2.005R/09_SourceHanSansSC.zip" \
+            SourceHanSansSC
+          ls -la ~/.local/share/fonts/source-han
+
+      - name: Check script
+        run: bash -n scripts/build_typst_pdf.sh
+
+      - name: Build PDF
+        run: ./scripts/build_typst_pdf.sh
+
+      - name: Inspect PDF
+        run: pdfinfo "output/pdf/DeepSeek Harness 实战指南.pdf"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dsh-book-pdf-typst
+          path: output/pdf/*.pdf
+          if-no-files-found: error

--- a/scripts/build_typst_pdf.sh
+++ b/scripts/build_typst_pdf.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 用 Typst 构建全书 PDF：inelegant-note 模板 + cmarker 直接载入 book/*.md。
+# 与 build_pdf.sh（pandoc + XeLaTeX）是两条独立的构建链路。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="$ROOT_DIR/output/pdf"
+OUTPUT_PDF="$OUTPUT_DIR/DeepSeek Harness 实战指南.pdf"
+
+if ! command -v typst >/dev/null 2>&1; then
+  echo "缺少 typst。可从 https://github.com/typst/typst/releases 下载后放进 PATH。" >&2
+  exit 1
+fi
+
+# 模板 inelegant-note 指定思源宋体 / 思源黑体，缺字体会退化成默认字体。
+for family in "Source Han Serif SC" "Source Han Sans SC"; do
+  if ! typst fonts | grep -qx "$family"; then
+    echo "缺少中文字体：$family" >&2
+    echo "可从 Adobe 下载后解压到 ~/.local/share/fonts 并运行 fc-cache -f：" >&2
+    echo "  https://github.com/adobe-fonts/source-han-serif/releases (09_SourceHanSerifSC.zip)" >&2
+    echo "  https://github.com/adobe-fonts/source-han-sans/releases  (09_SourceHanSansSC.zip)" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$OUTPUT_DIR"
+
+# --root 指到仓库根目录，正文里的 /book/... 路径才能解析。
+typst compile --root "$ROOT_DIR" "$ROOT_DIR/typst/main.typ" "$OUTPUT_PDF"
+
+echo "已生成：$OUTPUT_PDF"

--- a/typst/cover.typ
+++ b/typst/cover.typ
@@ -1,0 +1,123 @@
+// 封面，移植自 book/preamble.tex 里的 \maketitle。
+//
+// LaTeX 版和本模板的开本都是 185×260mm，所以坐标 1:1 沿用。品牌色、鱼形标记
+// 的路径数据和仓库地址都直接从 preamble.tex 读，两版共用一份定义，改一处即可。
+
+#import "@preview/inelegant-note:0.9.1": page-all, sans-font
+
+#let _preamble = read("/book/preamble.tex")
+
+#let _tex-value(pattern) = {
+  let hit = _preamble.match(regex(pattern))
+  assert(hit != none, message: "book/preamble.tex 里找不到：" + pattern)
+  hit.captures.at(0)
+}
+
+// \definecolor{DSHAccent}{HTML}{4D6BFE}
+#let brand-color(name) = rgb(
+  "#" + _tex-value("\\\\definecolor\\{" + name + "\\}\\{HTML\\}\\{([0-9A-Fa-f]{6})\\}"),
+)
+
+#let ink = brand-color("DSHInk")
+#let muted = brand-color("DSHMuted")
+#let accent = brand-color("DSHAccent")
+#let accent-dark = brand-color("DSHAccentDark")
+#let rule-colour = brand-color("DSHRule")
+
+#let repository-url = _tex-value("\\\\newcommand\\{\\\\DSHRepositoryURL\\}\\{([^}]*)\\}")
+
+// dsh 官方鱼形标记，viewBox 0 0 23.16 17.04，路径数据取自 preamble.tex。
+#let _fish-path = _tex-value("\\\\newcommand\\{\\\\DSHFishPathData\\}\\{([^}]*)\\}")
+
+#let fish-mark(width: 10mm, fill: accent) = image(
+  bytes(
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 23.16 17.04\">"
+      + "<path d=\"" + _fish-path + "\" fill=\"" + fill.to-hex() + "\"/>"
+      + "</svg>"
+  ),
+  format: "svg",
+  width: width,
+)
+
+#let github-mark(width: 4.2mm) = image("/book/assets/github-mark.svg", width: width)
+
+// 竖直居中地放一段内容：TikZ 的 anchor=west / anchor=center 对应到这里。
+#let _at(dx: 0mm, dy: 0mm, height: 10mm, body) = place(
+  top + center,
+  dx: dx,
+  dy: dy - height / 2,
+  box(height: height, align(horizon, body)),
+)
+
+#let cover-page(lead: [], brand: [], subtitle: []) = {
+  set page(
+    width: page-all.width,
+    height: page-all.height,
+    margin: 0mm,
+    numbering: none,
+    header: none,
+    footer: none,
+  )
+  set text(font: sans-font, fill: ink)
+
+  // 页眉的品牌签名：鱼形标记 + 字标 + 分隔线。
+  place(top + left, dx: 22mm, dy: 20mm, fish-mark(width: 10mm, fill: ink))
+  place(
+    top + left,
+    dx: 36mm,
+    dy: 20mm,
+    box(height: 10mm, align(horizon, text(size: 8.5pt, weight: "bold", tracking: 0.15em)[
+      DEEPSEEK HARNESS
+    ])),
+  )
+  place(
+    top + left,
+    dx: 22mm,
+    dy: 38mm,
+    line(length: page-all.width - 44mm, stroke: 0.7pt + rule-colour),
+  )
+
+  // 书名：主书名沿用 DSHInk，产品名沿用品牌主色 DSHAccent。
+  place(top + center, dy: 59mm, text(size: 29pt, weight: "bold", lead))
+  place(top + center, dy: 91mm, text(size: 39pt, weight: "bold", fill: accent, brand))
+  place(top + center, dy: 132mm, text(size: 16pt, fill: muted, subtitle))
+
+  // 模型 — Harness — 工具的关系示意，中心距页底 69mm。
+  let axis = page-all.height - 69mm
+  let label(body) = text(size: 12pt, weight: "bold", fill: muted, body)
+  _at(dx: -53mm, dy: axis, label[MODEL])
+  _at(dx: 53mm, dy: axis, label[TOOLS])
+  for dx in (-29.5mm, 29.5mm) {
+    place(top + center, dx: dx, dy: axis, line(length: 11mm, stroke: 1pt + rule-colour))
+  }
+  for dx in (-35mm, 35mm) {
+    _at(dx: dx, dy: axis, height: 2.7mm, circle(radius: 1.35mm, fill: accent, stroke: none))
+  }
+  _at(
+    dy: axis,
+    height: 15mm,
+    box(
+      width: 48mm,
+      height: 15mm,
+      fill: accent,
+      radius: 2mm,
+      align(center + horizon, text(size: 12pt, weight: "bold", fill: white)[DeepSeek Harness]),
+    ),
+  )
+
+  // 页脚的 GitHub 仓库入口。
+  place(
+    bottom + center,
+    dy: -28mm,
+    text(size: 13pt, fill: muted)[本书后续更新内容请关注 GitHub 仓库],
+  )
+  place(
+    bottom + center,
+    dy: -18mm,
+    link(repository-url)[
+      #box(baseline: 0.8mm, github-mark())
+      #h(2mm)
+      #text(size: 11.5pt, fill: accent-dark, repository-url)
+    ],
+  )
+}

--- a/typst/main.typ
+++ b/typst/main.typ
@@ -1,44 +1,13 @@
-// 《从零开始玩转 DeepSeek Harness》Typst 版
-//
-// 排版基于 inelegant-note 模板，正文由 cmarker 从 book/*.md 直接载入，
-// 部分与章节顺序读取 book/outline.md（全书目录的唯一依据）。
-
 #import "@preview/inelegant-note:0.9.1": *
 #import "markdown.typ": render-markdown
+#import "cover.typ": accent, cover-page
 
-#let accent = rgb("#253A9B")
-#let muted = rgb("#5B6478")
+#set document(title: "从零开始玩转 DeepSeek Harness")
 
-// 封面主图：沿用现有 PDF 封面「模型 — Harness — 工具」的关系示意。
-#let cover-art = {
-  set text(font: ("Source Han Sans SC",), fill: muted, weight: "bold")
-  align(center + horizon)[
-    #v(1fr)
-    #text(size: 8.5pt, tracking: 2pt, fill: black)[DEEPSEEK HARNESS]
-    #v(2fr)
-    #grid(
-      columns: (auto, 14mm, auto, 14mm, auto),
-      align: horizon,
-      text(size: 11pt)[MODEL],
-      line(length: 100%, stroke: 0.8pt + muted),
-      box(
-        fill: accent,
-        radius: 2mm,
-        inset: (x: 6mm, y: 4mm),
-        text(size: 11pt, fill: white)[DeepSeek Harness],
-      ),
-      line(length: 100%, stroke: 0.8pt + muted),
-      text(size: 11pt)[TOOLS],
-    )
-    #v(3fr)
-  ]
-}
-
-#cover-environment(
-  title: [从零开始玩转 DeepSeek Harness],
-  subtitle: "面向普通用户的 Agent 实践指南",
-  author: "Prism-Shadow/dsh-book",
-  cover-image: cover-art,
+#cover-page(
+  lead: [从零开始玩转],
+  brand: [DeepSeek Harness],
+  subtitle: [面向普通用户的 Agent 实践指南],
 )
 
 #show: overall

--- a/typst/main.typ
+++ b/typst/main.typ
@@ -1,0 +1,103 @@
+// 《从零开始玩转 DeepSeek Harness》Typst 版
+//
+// 排版基于 inelegant-note 模板，正文由 cmarker 从 book/*.md 直接载入，
+// 部分与章节顺序读取 book/outline.md（全书目录的唯一依据）。
+
+#import "@preview/inelegant-note:0.9.1": *
+#import "markdown.typ": render-markdown
+
+#let accent = rgb("#253A9B")
+#let muted = rgb("#5B6478")
+
+// 封面主图：沿用现有 PDF 封面「模型 — Harness — 工具」的关系示意。
+#let cover-art = {
+  set text(font: ("Source Han Sans SC",), fill: muted, weight: "bold")
+  align(center + horizon)[
+    #v(1fr)
+    #text(size: 8.5pt, tracking: 2pt, fill: black)[DEEPSEEK HARNESS]
+    #v(2fr)
+    #grid(
+      columns: (auto, 14mm, auto, 14mm, auto),
+      align: horizon,
+      text(size: 11pt)[MODEL],
+      line(length: 100%, stroke: 0.8pt + muted),
+      box(
+        fill: accent,
+        radius: 2mm,
+        inset: (x: 6mm, y: 4mm),
+        text(size: 11pt, fill: white)[DeepSeek Harness],
+      ),
+      line(length: 100%, stroke: 0.8pt + muted),
+      text(size: 11pt)[TOOLS],
+    )
+    #v(3fr)
+  ]
+}
+
+#cover-environment(
+  title: [从零开始玩转 DeepSeek Harness],
+  subtitle: "面向普通用户的 Agent 实践指南",
+  author: "Prism-Shadow/dsh-book",
+  cover-image: cover-art,
+)
+
+#show: overall
+
+// 模板默认的代码字体是 Consolas，本机没有，换成等宽的 DejaVu Sans Mono，
+// 中文仍由思源黑体兜底。
+#show raw: set text(
+  font: ((name: "DejaVu Sans Mono", covers: "latin-in-cjk"), "Source Han Sans SC"),
+)
+
+// 书稿用引用块承载提示词，给它一条主色竖线，和正文区分开。
+#show quote.where(block: true): it => block(
+  width: 100%,
+  inset: (left: 1em, y: 0.6em),
+  stroke: (left: 2pt + accent),
+  it.body,
+)
+
+#front-matter[
+  #render-markdown("/book/introduction.md", label-prefix: "intro-")
+
+  #my-outline()
+]
+
+#show: main-matter
+
+// 从 outline.md 解析「部分 / 章」的顺序。
+#let book-plan = {
+  let items = ()
+  for line in read("/book/outline.md").split("\n") {
+    let text = line.trim()
+    if text.starts-with("# ") {
+      let hit = text.slice(2).trim().match(regex("^第[^\\s　]+部分[\\s　]+(.+)$"))
+      if hit != none {
+        items.push((kind: "part", title: hit.captures.at(0)))
+      }
+    } else if text.starts-with("## ") {
+      let hit = text.slice(3).trim().match(regex("^第([0-9]+)章"))
+      if hit != none {
+        items.push((kind: "chapter", number: int(hit.captures.at(0))))
+      }
+    }
+  }
+  items
+}
+
+#for item in book-plan {
+  if item.kind == "part" {
+    part-page(item.title)
+  } else {
+    // 模板的章标题里用 `counter(image)` 复位图表计数，在 Typst 0.15 上不生效，
+    // 会让图号一路累加（图 9.78）。这里按章显式复位。
+    counter(figure.where(kind: image)).update(0)
+    counter(figure.where(kind: table)).update(0)
+    counter(figure.where(kind: raw)).update(0)
+    counter(math.equation).update(0)
+    render-markdown(
+      "/book/chapter" + str(item.number) + ".md",
+      label-prefix: "ch" + str(item.number) + "-",
+    )
+  }
+}

--- a/typst/markdown.typ
+++ b/typst/markdown.typ
@@ -1,0 +1,190 @@
+// 用 cmarker 把 book/*.md 载入 Typst。
+//
+// 书稿正文是 Pandoc 风味的 Markdown，其中三处扩展语法 CommonMark 不认识：
+//   1. 标题尾部的 `{#ch-1}` / `{#sec-1-1}` 锚点；
+//   2. 图片尾部的 `{width=68%}` / `{.book-technical-figure width=72%}` 属性；
+//   3. YAML front matter（只有 introduction.md 有）。
+// 这里先把它们规范成 cmarker 支持的写法，再交给 cmarker 转换。
+
+#import "@preview/cmarker:0.1.10"
+#import "@preview/mitex:0.2.7": mitex
+#import "@preview/zebraw:0.6.1": zebraw
+
+// 书稿根目录，图片路径都相对于它。
+#let book-root = "/book/"
+
+#let _escape-attr(value) = value
+  .replace("&", "&amp;")
+  .replace("\"", "&quot;")
+  .replace("<", "&lt;")
+  .replace(">", "&gt;")
+
+// 去掉 YAML front matter。
+#let _strip-front-matter(src) = src.replace(
+  regex("(?s)^---\r?\n.*?\r?\n---\r?\n"),
+  "",
+)
+
+// 去掉标题尾部的 `{#id}`、`{.class}` 属性。
+// 全书没有 `](#id)` 形式的交叉引用，这些锚点只服务于网页版，直接丢弃即可。
+#let _strip-heading-attrs(src) = src.replace(
+  regex("(?m)^(#{1,6}[ \t]+\\S.*?)[ \t]*\\{[#.][^}\n]*\\}[ \t]*$"),
+  m => m.captures.at(0),
+)
+
+// 独占一行的图片：把 `{width=68%}` 之类的属性转成 `<img>`，cmarker 认识宽高。
+#let _rewrite-images(src) = src.replace(
+  regex("(?m)^!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)(\\{[^}\n]*\\})?[ \t]*$"),
+  m => {
+    let alt = m.captures.at(0)
+    let path = m.captures.at(1)
+    let attrs = m.captures.at(2)
+    let extra = ""
+    if attrs != none {
+      for key in ("width", "height") {
+        let hit = attrs.match(regex(key + "[ \t]*=[ \t]*\"?([0-9.]+%?)\"?"))
+        if hit != none {
+          extra += " " + key + "=\"" + hit.captures.at(0) + "\""
+        }
+      }
+    }
+    "<img src=\"" + _escape-attr(path) + "\" alt=\"" + _escape-attr(alt) + "\"" + extra + ">"
+  },
+)
+
+// --- Pandoc 原始 LaTeX 块 -----------------------------------------------
+//
+// 书稿里有 22 处 ```{=latex} 块，只有三种形态：
+//   * \Needspace{..}：给 XeLaTeX 的分页提示，Typst 自己分页，直接丢弃；
+//   * 单图 figure：\includegraphics + \caption；
+//   * minipage 拼图：多张图并排，每张下面一行小字，整组共用一个 \caption。
+// 这里把它们翻译成 `<!--raw-typst -->` 块，交给下面的 latex-figure 渲染。
+
+#let _typst-str(value) = "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+// `0.96\textwidth` -> 96%，`\linewidth` -> 100%
+#let _tex-width(value) = {
+  let hit = value.match(regex("^([0-9.]+)"))
+  let ratio = if hit == none { 1.0 } else { float(hit.captures.at(0)) }
+  str(calc.round(ratio * 100, digits: 2)) + "%"
+}
+
+#let _rewrite-latex-blocks(src) = src.replace(
+  regex("(?ms)^```\\{=latex\\}\r?\n(.*?)\r?\n```[ \t]*$"),
+  m => {
+    let body = m.captures.at(0)
+    let pieces = ()
+    for hit in body.matches(regex(
+      "\\\\includegraphics\\[width=([^\\]]*)\\]\\{([^}]*)\\}"
+        + "(?:[ \t]*\r?\n[ \t]*\\\\par\\\\smallskip\\\\sffamily\\\\footnotesize[ \t]*([^\r\n]*))?"
+    )) {
+      let note = hit.captures.at(2)
+      pieces.push(
+        "("
+          + "path: " + _typst-str(hit.captures.at(1)) + ", "
+          + "width: " + _tex-width(hit.captures.at(0)) + ", "
+          + "note: " + (if note == none { "none" } else { _typst-str(note.trim()) })
+          + ")"
+      )
+    }
+    if pieces.len() == 0 {
+      // 只剩 \Needspace 之类的排版提示，Typst 用不上。
+      return ""
+    }
+    let caption = body.match(regex("\\\\caption\\{([^}]*)\\}"))
+    (
+      "<!--raw-typst #latex-figure("
+        + "caption: "
+        + (if caption == none { "none" } else { _typst-str(caption.captures.at(0)) })
+        + ", ("
+        + pieces.join(", ")
+        + (if pieces.len() == 1 { ",)" } else { ")" })
+        + ") -->"
+    )
+  },
+)
+
+#let normalize(src) = _rewrite-images(_rewrite-latex-blocks(_strip-heading-attrs(_strip-front-matter(src))))
+
+// --- 渲染 ---------------------------------------------------------------
+
+// 图片路径相对 book/ 解析；正文里的图片都独占一行，统一渲染成带题注的图。
+#let _plain-image(path, ..args) = image(
+  if path.starts-with("/") or path.contains("://") { path } else { book-root + path },
+  ..args,
+)
+
+#let _image(path, alt: none, ..args) = {
+  let body = _plain-image(path, ..args)
+  if alt == none or alt == "" {
+    align(center, body)
+  } else {
+    figure(body, caption: alt)
+  }
+}
+
+// 由 `_rewrite-latex-blocks` 生成的调用：单图直接排，多图按两列拼。
+#let _latex-figure(items, caption: none) = {
+  let cell(it) = {
+    align(center)[
+      #_plain-image(it.path, width: it.width)
+      #if it.note != none [
+        #v(0.4em, weak: true)
+        #text(font: ("Source Han Sans SC",), size: 0.85em, it.note)
+      ]
+    ]
+  }
+  let body = if items.len() == 1 {
+    cell(items.first())
+  } else {
+    grid(columns: (1fr, 1fr), column-gutter: 4mm, row-gutter: 4mm, ..items.map(cell))
+  }
+  if caption == none { align(center, body) } else { figure(body, caption: caption) }
+}
+
+// 代码块用模板自带的 zebraw 显示，行内代码保持默认。
+//
+// 书稿里有 21 个代码块的最长行超过版心宽度（最长 92 字符），Typst 不会折行，
+// 所以先量一下自然宽度，超宽的块整块按比例缩小字号。
+#let code-width = 145mm // = page-all.width - 2 * page-all.mar-x
+#let _raw(body, block: false, ..args) = {
+  let it = raw(body, block: block, ..args)
+  if not block { return it }
+  context {
+    let avail = code-width - 4mm // 留出 zebraw 的内边距
+    let natural = measure(it).width
+    if natural > avail {
+      show raw: set text(size: (avail / natural) * 1em)
+      zebraw(numbering: false, it)
+    } else {
+      zebraw(numbering: false, it)
+    }
+  }
+}
+
+// 书稿里用 `<span class="prompt-title">提示词内容：</span>` 标注提示词块的抬头。
+#let _span(attrs, body) = {
+  if attrs.at("class", default: "") == "prompt-title" {
+    strong(body)
+  } else {
+    body
+  }
+}
+
+/// 渲染一个 Markdown 文件。
+/// - path: 相对仓库根目录的路径，例如 `/book/chapter1.md`
+/// - label-prefix: 标题标签前缀，避免各章同名小节的标签互相冲突
+#let render-markdown(path, label-prefix: "") = cmarker.render(
+  normalize(read(path)),
+  // 正文含大量 `--flag`、`"路径"` 等技术写法，关掉智能标点以免被改写。
+  smart-punctuation: false,
+  math: mitex,
+  set-document-title: false,
+  label-prefix: label-prefix,
+  html: (span: _span),
+  scope: (
+    image: _image,
+    raw: _raw,
+    latex-figure: _latex-figure,
+  ),
+)


### PR DESCRIPTION
## 本次修改

新增一条 Typst 版 PDF 构建链路，与现有的 pandoc + XeLaTeX 并行，两者互不影响。没有改动任何书稿正文。

排版模板用 [inelegant-note](https://github.com/typetypewriter/inelegant-note)（从 Typst packages 安装），正文由 [cmarker](https://typst.app/universe/package/cmarker) 直接载入 `book/*.md`，不经过中间的 Markdown 拼装。

**新增文件**

- `typst/markdown.typ` — cmarker 载入层。书稿是 Pandoc 风味 Markdown，其中几处扩展语法 CommonMark 不认识，先规范化再交给 cmarker：
  - 标题尾部的 `{#ch-1}` / `{#sec-1-1}` 锚点（全书没有 `](#id)` 交叉引用，只服务网页版）
  - 图片尾部的 `{width=68%}` / `{.book-technical-figure width=72%}`
  - ` ```{=latex} ` 原始块（22 处）：单图 figure、minipage 拼图转两列 grid、`\Needspace` 丢弃
  - `introduction.md` 的 YAML front matter
  - 公式走 mitex，代码块走 zebraw，`<span class="prompt-title">` 渲染成加粗抬头
- `typst/main.typ` — 封面、前辅助页、目录和正文。部分与章节顺序从 `book/outline.md` 解析，保持"目录唯一依据"的约束。
- `scripts/build_typst_pdf.sh` — 构建脚本，带思源字体缺失检查。

**排版上修了两处**

- inelegant-note 在章标题里用 `counter(image).update(0)` 复位图号，在 Typst 0.15 上不生效，图号会一路累加（出现"图 9.78"）。改为按章显式复位 `counter(figure.where(kind: image))` 等。
- 21 个代码块的最长行超过版心（最长 92 字符），Typst 不会自动折行。加了按块 `measure` + 自动缩字号，缩放后仍可跨页断开。

**产物**：194 页，16 开 185×260mm，图号、公式号、目录部分栏、页眉页脚均正常。

**依赖**：typst 0.15.1；`@preview` 包 inelegant-note 0.9.1、cmarker 0.1.10、mitex 0.2.7、zebraw 0.6.1（自动安装）；中文字体需要思源宋体 SC 与思源黑体 SC（模板指定，构建脚本会检查并给出下载地址）。

**CI**：`build-book.yml` 里新增并行的 `typst-pdf` job，装 typst 0.15.1 + 思源字体后跑构建并上传产物，原有的 `pdf` job（pandoc + XeLaTeX）没有改动。

Ubuntu 源里只有同源的 Noto CJK，家族名和模板要求的 Source Han 对不上，所以直接取 Adobe 发行版；模板经 cuti 伪粗体渲染中文字重，只需要 Regular 和 Bold 两个字重，本地验证过 4 个 OTF 与完整安装产物一致（同为 194 页、版式相同），缓存约 80MB。

## 自查

- [x] Markdown 标题与 `book/outline.md` 一致（未改动书稿，章节顺序改为从 outline 解析）
- [x] 操作步骤已经实际验证（本地构建通过，逐页核对了封面、目录、部分页、图表、公式、代码块）
- [x] 图片路径能够正常打开（全部 png/svg 正常渲染，含 17 张 SVG）
- [x] 截图已隐藏密钥、账号和内部信息（未新增或修改截图）
- [x] 没有提交 `deepseek-harness/` 或其他本地参考文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCLZc4HXyVnmLurZFpfuyi
