### PR TITLE
自动发布最新版 PDF

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-book-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pdf:
     runs-on: ubuntu-latest
@@ -75,3 +82,38 @@ jobs:
           name: dsh-book-pdf
           path: output/pdf/*.pdf
           if-no-files-found: error
+
+  release:
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'Prism-Shadow/deepseek-harness-book'
+    needs: pdf
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dsh-book-pdf
+          path: release
+
+      - name: Publish rolling PDF release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          asset="$RUNNER_TEMP/DeepSeek-Harness-实战指南.pdf"
+          cp "release/DeepSeek Harness 实战指南.pdf" "$asset"
+
+          if ! gh release view latest >/dev/null 2>&1; then
+            gh release create latest \
+              --target "$GITHUB_SHA" \
+              --title "最新版（持续更新）" \
+              --notes "由 main 分支自动构建，附件会随书稿更新。" \
+              --prerelease
+          fi
+
+          gh release upload latest "$asset" --clobber

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 </div>
 
 <div align="center">
-  <a href="https://dshbook.penguin.ooo/">在线阅读</a>
+  <a href="https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest/DeepSeek-Harness-实战指南.pdf">下载最新版 PDF</a>
   ｜
-  <a href="https://dshbook.penguin.ooo/chapter1/">从第 1 章开始</a>
+  <a href="https://dshbook.penguin.ooo/">在线阅读</a>
 </div>
 
 ## 📖 这本书写什么
@@ -91,6 +91,7 @@ mkdocs serve
 
 ## 🔗 相关链接
 
+- [下载最新版 PDF](https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest/DeepSeek-Harness-实战指南.pdf)
 - [本书在线阅读](https://dshbook.penguin.ooo/)
 - [DeepSeek Harness 官方介绍](https://www.deepseek.com/harness/)
 - [DeepSeek Harness 官方源码](https://github.com/deepseek-ai/deepseek-harness)


### PR DESCRIPTION
## 修改内容

- main 分支构建成功后，将 PDF 上传到 latest 滚动预发布
- Release 附件统一命名为 DeepSeek-Harness-实战指南.pdf
- README 顶部和相关链接增加最新版 PDF 下载入口
- 限制 Release 写权限，并避免并发构建覆盖新版本

## 验证

- python3 -m unittest discover -s tests
- bash -n scripts/build_typst_pdf.sh
- git diff --check