### PR TITLE
修复滚动 PDF 发布标签

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -108,12 +108,12 @@ jobs:
           asset="$RUNNER_TEMP/DeepSeek-Harness-实战指南.pdf"
           cp "release/DeepSeek Harness 实战指南.pdf" "$asset"
 
-          if ! gh release view latest >/dev/null 2>&1; then
-            gh release create latest \
+          if gh release view latest-pdf >/dev/null 2>&1; then
+            gh release upload latest-pdf "$asset" --clobber
+          else
+            gh release create latest-pdf "$asset" \
               --target "$GITHUB_SHA" \
               --title "最新版（持续更新）" \
               --notes "由 main 分支自动构建，附件会随书稿更新。" \
               --prerelease
           fi
-
-          gh release upload latest "$asset" --clobber

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest/DeepSeek-Harness-实战指南.pdf">下载最新版 PDF</a>
+  <a href="https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-实战指南.pdf">下载最新版 PDF</a>
   ｜
   <a href="https://dshbook.penguin.ooo/">在线阅读</a>
 </div>
@@ -91,7 +91,7 @@ mkdocs serve
 
 ## 🔗 相关链接
 
-- [下载最新版 PDF](https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest/DeepSeek-Harness-实战指南.pdf)
+- [下载最新版 PDF](https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-实战指南.pdf)
 - [本书在线阅读](https://dshbook.penguin.ooo/)
 - [DeepSeek Harness 官方介绍](https://www.deepseek.com/harness/)
 - [DeepSeek Harness 官方源码](https://github.com/deepseek-ai/deepseek-harness)


### PR DESCRIPTION
## 修改内容

- 将滚动 PDF Release 标签由已锁定的 latest 改为 latest-pdf
- 首次创建 Release 时直接附带 PDF，后续覆盖同名附件
- 同步更新 README 中的最新版 PDF 下载地址

## 验证

- 10 项单元测试通过
- 工作流 YAML 解析通过
- Shell 与差异格式检查通过