### PR TITLE
修复 PDF Release 附件名

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          asset="$RUNNER_TEMP/DeepSeek-Harness-实战指南.pdf"
+          asset="$RUNNER_TEMP/DeepSeek-Harness-Practical-Guide-zh-CN.pdf"
           cp "release/DeepSeek Harness 实战指南.pdf" "$asset"
 
           if gh release view latest-pdf >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-实战指南.pdf">下载最新版 PDF</a>
+  <a href="https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-Practical-Guide-zh-CN.pdf">下载最新版 PDF</a>
   ｜
   <a href="https://dshbook.penguin.ooo/">在线阅读</a>
 </div>
@@ -91,7 +91,7 @@ mkdocs serve
 
 ## 🔗 相关链接
 
-- [下载最新版 PDF](https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-实战指南.pdf)
+- [下载最新版 PDF](https://github.com/Prism-Shadow/deepseek-harness-book/releases/download/latest-pdf/DeepSeek-Harness-Practical-Guide-zh-CN.pdf)
 - [本书在线阅读](https://dshbook.penguin.ooo/)
 - [DeepSeek Harness 官方介绍](https://www.deepseek.com/harness/)
 - [DeepSeek Harness 官方源码](https://github.com/deepseek-ai/deepseek-harness)


### PR DESCRIPTION
## 修改内容

- 将 Release 附件名改为 DeepSeek-Harness-Practical-Guide-zh-CN.pdf
- 同步更新 README 顶部和相关链接中的下载地址

## 验证

- 10 项单元测试通过
- 工作流 YAML 解析通过
- Shell 与差异格式检查通过